### PR TITLE
Update KNPLabs dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "knplabs/packagist-api": "0.1.*",
-        "knplabs/github-api": "1.2.*",
+        "knplabs/packagist-api": "~1.0",
+        "knplabs/github-api": "~1.4",
         "athari/yalinqo": "*"
     },
     "require-dev": {


### PR DESCRIPTION
The required version of the packagist-api did no longer exist. I also upped the github-api at the same time
